### PR TITLE
Disable slider control arrows

### DIFF
--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useEffect, useRef, useState } from 'react'
+import { FC, ReactNode, RefObject, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import Container from '../Container'
 import { mq } from '../../styles.config'
@@ -123,18 +123,20 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
     next:false
   }
   const [disabledArrow, setDisabledArrow] = useState<DisabledArrowsType>(initialArrowsState)
+  const [scrolling, setScrolling] = useState(false)
 
   useEffect(() => {
     const sliderElem = sliderRef.current
     if (!sliderElem || !sliderElem.firstChild || !sliderElem.lastChild) return
     firstSlideRef.current = sliderElem.firstChild.firstChild as Element
     lastSlideRef.current = sliderElem.firstChild.lastChild as Element
-    observer.current =new IntersectionObserver(
-      (entries) => entries.forEach(entry => {
+    
+    observer.current = new IntersectionObserver(
+      entries => entries.forEach(entry => {
         if(entry.target === firstSlideRef.current) setDisabledArrow(prev => ({...prev, previous: entry.isIntersecting}))
         else setDisabledArrow(prev => ({...prev, next: entry.isIntersecting}))
       }),
-      { threshold: 1 }
+      { threshold: 1, rootMargin: `${firstSlideRef.current.getBoundingClientRect().height}px`}
     )
     observer.current.observe(firstSlideRef.current)
     observer.current.observe(lastSlideRef.current)
@@ -142,6 +144,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
   },[sliderRef])
 
   const scrollSlides = (slidesToScroll: number) => {
+    setScrolling(true)
     const sliderElem = sliderRef.current
     if (!sliderElem) return
     const slide1 = sliderElem.firstChild?.childNodes[0] as Element
@@ -154,6 +157,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
       left: destination,
       behavior: 'smooth'
     })
+    setTimeout(() => setScrolling(false), 300)
   }
 
   return (
@@ -162,7 +166,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
         <Header>
           <h2>{title}</h2>
           <Controls>
-            <button onClick={() => scrollSlides(-2)} disabled={disabledArrow.previous}>
+            <button onClick={() => scrollSlides(-2)} disabled={(disabledArrow.previous || scrolling)}>
               <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M6.85355 3.14645C7.04882 3.34171 7.04882 3.65829 6.85355 3.85355L3.70711 7H12.5C12.7761 7 13 7.22386 13 7.5C13 7.77614 12.7761 8 12.5 8H3.70711L6.85355 11.1464C7.04882 11.3417 7.04882 11.6583 6.85355 11.8536C6.65829 12.0488 6.34171 12.0488 6.14645 11.8536L2.14645 7.85355C1.95118 7.65829 1.95118 7.34171 2.14645 7.14645L6.14645 3.14645C6.34171 2.95118 6.65829 2.95118 6.85355 3.14645Z"
@@ -170,7 +174,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
                 />
               </svg>
             </button>
-            <button onClick={() => scrollSlides(2)} disabled={disabledArrow.next}>
+            <button onClick={() => scrollSlides(2)} disabled={(disabledArrow.next || scrolling)}>
               <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M8.14645 3.14645C8.34171 2.95118 8.65829 2.95118 8.85355 3.14645L12.8536 7.14645C13.0488 7.34171 13.0488 7.65829 12.8536 7.85355L8.85355 11.8536C8.65829 12.0488 8.34171 12.0488 8.14645 11.8536C7.95118 11.6583 7.95118 11.3417 8.14645 11.1464L11.2929 8H2.5C2.22386 8 2 7.77614 2 7.5C2 7.22386 2.22386 7 2.5 7H11.2929L8.14645 3.85355C7.95118 3.65829 7.95118 3.34171 8.14645 3.14645Z"

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -1,7 +1,8 @@
-import { FC, ReactNode, useRef } from 'react'
+import { FC, ReactNode, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import Container from '../Container'
 import { mq } from '../../styles.config'
+import { DisabledArrowsType } from './types'
 
 const Root = styled.section`
   position: relative;
@@ -103,8 +104,36 @@ const Controls = styled.div`
 const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title }) => {
   const sliderRef = useRef<null | HTMLDivElement>(null)
   const trackRef = useRef<null | HTMLDivElement>(null)
+  const lastSlideRef = useRef<null | Element>(null)
+  const firstSlideRef = useRef<null | Element>(null)
+  const observer = useRef<null | IntersectionObserver>(null)
+
+  const initialArrowsState = {
+    previous: true, 
+    next:false
+  }
+  const [disabledArrow, setDisabledArrow] = useState<DisabledArrowsType>(initialArrowsState)
+
+  useEffect(() => {
+    const sliderElem = sliderRef.current
+    if (!sliderElem || !sliderElem.firstChild) return
+    firstSlideRef.current = sliderElem.firstChild.firstChild as Element
+    lastSlideRef.current = sliderElem.firstChild.lastChild as Element
+    observer.current =new IntersectionObserver(
+      (entries) => entries.forEach(entry => {
+        if(entry.target === firstSlideRef.current) setDisabledArrow(prev => ({...prev, previous: entry.isIntersecting}))
+        else setDisabledArrow(prev => ({...prev, next: entry.isIntersecting}))
+      }),
+      { threshold: 1 }
+    )
+    observer.current.observe(firstSlideRef.current)
+    observer.current.observe(lastSlideRef.current)
+    return () => { observer.current?.disconnect() }
+  },[sliderRef])
 
   const scrollSlides = (slidesToScroll: number) => {
+    // todo disable click when scrolling
+    console.log('clicked')
     const sliderElem = sliderRef.current
     if (!sliderElem) return
     const slide1 = sliderElem.firstChild?.childNodes[0] as Element
@@ -125,7 +154,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
         <Header>
           <h2>{title}</h2>
           <Controls>
-            <button onClick={() => scrollSlides(-2)}>
+            <button onClick={() => scrollSlides(-2)} disabled={disabledArrow.previous}>
               <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M6.85355 3.14645C7.04882 3.34171 7.04882 3.65829 6.85355 3.85355L3.70711 7H12.5C12.7761 7 13 7.22386 13 7.5C13 7.77614 12.7761 8 12.5 8H3.70711L6.85355 11.1464C7.04882 11.3417 7.04882 11.6583 6.85355 11.8536C6.65829 12.0488 6.34171 12.0488 6.14645 11.8536L2.14645 7.85355C1.95118 7.65829 1.95118 7.34171 2.14645 7.14645L6.14645 3.14645C6.34171 2.95118 6.65829 2.95118 6.85355 3.14645Z"
@@ -133,7 +162,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
                 />
               </svg>
             </button>
-            <button onClick={() => scrollSlides(2)}>
+            <button onClick={() => scrollSlides(2)} disabled={disabledArrow.next}>
               <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M8.14645 3.14645C8.34171 2.95118 8.65829 2.95118 8.85355 3.14645L12.8536 7.14645C13.0488 7.34171 13.0488 7.65829 12.8536 7.85355L8.85355 11.8536C8.65829 12.0488 8.34171 12.0488 8.14645 11.8536C7.95118 11.6583 7.95118 11.3417 8.14645 11.1464L11.2929 8H2.5C2.22386 8 2 7.77614 2 7.5C2 7.22386 2.22386 7 2.5 7H11.2929L8.14645 3.85355C7.95118 3.65829 7.95118 3.34171 8.14645 3.14645Z"

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, RefObject, useEffect, useRef, useState } from 'react'
+import { FC, ReactNode, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import Container from '../Container'
 import { mq } from '../../styles.config'
@@ -120,7 +120,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
 
   const initialArrowsState = {
     previous: true, 
-    next:false
+    next: false
   }
   const [disabledArrow, setDisabledArrow] = useState<DisabledArrowsType>(initialArrowsState)
   const [scrolling, setScrolling] = useState(false)
@@ -130,13 +130,12 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
     if (!sliderElem || !sliderElem.firstChild || !sliderElem.lastChild) return
     firstSlideRef.current = sliderElem.firstChild.firstChild as Element
     lastSlideRef.current = sliderElem.firstChild.lastChild as Element
-    
     observer.current = new IntersectionObserver(
       entries => entries.forEach(entry => {
         if(entry.target === firstSlideRef.current) setDisabledArrow(prev => ({...prev, previous: entry.isIntersecting}))
         else setDisabledArrow(prev => ({...prev, next: entry.isIntersecting}))
       }),
-      { threshold: 1, rootMargin: `${firstSlideRef.current.getBoundingClientRect().height}px`}
+      { threshold: 1, rootMargin: `${firstSlideRef.current.getBoundingClientRect().height}px` }
     )
     observer.current.observe(firstSlideRef.current)
     observer.current.observe(lastSlideRef.current)

--- a/src/Slider/Slider.tsx
+++ b/src/Slider/Slider.tsx
@@ -93,6 +93,16 @@ const Header = styled.div`
         transform: translate(2px, 2px);
       }
     }
+
+    &:disabled {
+      color: #ccc;
+      transform: none;
+      cursor: initial;
+      &:before {
+        background-color: #ccc;
+        transform: translate(2px, 2px);
+      }
+    }
   }
 `
 const Controls = styled.div`
@@ -116,7 +126,7 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
 
   useEffect(() => {
     const sliderElem = sliderRef.current
-    if (!sliderElem || !sliderElem.firstChild) return
+    if (!sliderElem || !sliderElem.firstChild || !sliderElem.lastChild) return
     firstSlideRef.current = sliderElem.firstChild.firstChild as Element
     lastSlideRef.current = sliderElem.firstChild.lastChild as Element
     observer.current =new IntersectionObserver(
@@ -132,8 +142,6 @@ const Slider: FC<{ children: ReactNode[]; title: string }> = ({ children, title 
   },[sliderRef])
 
   const scrollSlides = (slidesToScroll: number) => {
-    // todo disable click when scrolling
-    console.log('clicked')
     const sliderElem = sliderRef.current
     if (!sliderElem) return
     const slide1 = sliderElem.firstChild?.childNodes[0] as Element

--- a/src/Slider/types.ts
+++ b/src/Slider/types.ts
@@ -1,0 +1,4 @@
+export type DisabledArrowsType = {
+  previous: boolean,
+  next: boolean
+}


### PR DESCRIPTION
As we spoke during the interview I wrote the functionality using IntersectionObserver, not calculating widths ( If you are interested I can write it as well), because I think that it's more efficient, and certainly more React way. As for disabling buttons when the slider is scrolling, I made it simply, because I didn't want to alter the original animation.